### PR TITLE
feat: added support for import statement (for in-memory script)

### DIFF
--- a/releases/v0.1.5.md
+++ b/releases/v0.1.5.md
@@ -1,0 +1,6 @@
+k6deps `v0.1.5` is here 🎉!
+
+This release includes:
+
+- In addition to the `require()` function, `Analyze()` also handles the `import` statement for the script in the memory.
+  (it has handled the script loaded by `Analyze()` so far)


### PR DESCRIPTION
In addition to the `require()` function, `Analyze()` also handles the `import` statement for the script in the memory.
(it has handled the script loaded by `Analyze()` so far)
