### PR TITLE
build metadata support in version constraints

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -12,7 +12,7 @@ import (
 //nolint:gochecknoglobals
 var (
 	srcName       = `(?P<name>k6|k6/[^/]{2}.*|k6/[^x]/.*|k6/x/[/0-9a-zA-Z_-]+|(@[a-zA-Z0-9-_]+/)?xk6-([a-zA-Z0-9-_]+)((/[a-zA-Z0-9-_]+)*))` //nolint:lll
-	srcConstraint = `[vxX*|,&\^0-9.+-><=, ~]+`
+	srcConstraint = `=?v?0\.0\.0\+[0-9A-Za-z-]+|[vxX*|,&\^0-9.+-><=, ~]+`
 
 	reName = regexp.MustCompile(srcName)
 

--- a/dependency.go
+++ b/dependency.go
@@ -24,7 +24,9 @@ var (
 
 	defaultConstraints, _ = semver.NewConstraint(defaultConstraintsString)
 
-	reDependency             = regexp.MustCompile(`(?P<name>[0-9a-zA-Z/@_-]+) *(?P<constraints>[vxX*|,&\^0-9.+-><=, ~]+)?`)
+	srcDependency = `(?P<name>[0-9a-zA-Z/@_-]+) *(?P<constraints>` + srcConstraint + `)?`
+
+	reDependency             = regexp.MustCompile(srcDependency)
 	idxDependencyName        = reDependency.SubexpIndex("name")
 	idxDependencyConstraints = reDependency.SubexpIndex("constraints")
 )

--- a/dependency_internal_test.go
+++ b/dependency_internal_test.go
@@ -90,3 +90,21 @@ func Test_Dependency_marshalJS(t *testing.T) {
 		require.Error(t, err)
 	}
 }
+
+func Test_reDependency(t *testing.T) {
+	t.Parallel()
+
+	var d Dependency
+
+	require.NoError(t, d.UnmarshalText([]byte("k6*")))
+	require.Equal(t, "*", d.Constraints.String())
+
+	require.NoError(t, d.UnmarshalText([]byte("k6 >= v0.55")))
+	require.Equal(t, ">=v0.55", d.Constraints.String())
+
+	require.NoError(t, d.UnmarshalText([]byte("k6 v0.0.0+135f85b")))
+	require.Equal(t, "v0.0.0+135f85b", d.Constraints.String())
+
+	require.NoError(t, d.UnmarshalText([]byte("k6 v0.0.0+90bb941")))
+	require.Equal(t, "v0.0.0+90bb941", d.Constraints.String())
+}

--- a/releases/v0.1.8.md
+++ b/releases/v0.1.8.md
@@ -1,0 +1,7 @@
+k6deps `v0.1.8` is here 🎉!
+
+This release includes:
+
+- fix [semvers with build metadata are unmarshalled incorrectly](https://github.com/grafana/k6deps/issues/43)
+- If the version is `v0.0.0`, then support for build metadata in version constraints according to semver
+


### PR DESCRIPTION
If the version is `v0.0.0`, then support for build metadata in version constraints according to semver
