### PR TITLE
Introduces Reader into k6deps.Source

### DIFF
--- a/archive_test.go
+++ b/archive_test.go
@@ -1,6 +1,7 @@
 package k6deps
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,6 +27,26 @@ func Test_analyzeArchive(t *testing.T) {
 
 	expected, err := Analyze(opts)
 
+	require.NoError(t, err)
+
+	require.Equal(t, expected.String(), actual.String())
+}
+
+func Test_analyzeArchive_Reader(t *testing.T) {
+	t.Parallel()
+
+	file, err := os.Open(filepath.Join("testdata", "archive.tar")) //nolint:forbidigo
+	require.NoError(t, err)
+	defer file.Close() //nolint:errcheck
+
+	opts := &Options{
+		Archive: Source{Reader: file},
+	}
+
+	actual, err := Analyze(opts)
+	require.NoError(t, err)
+
+	expected, err := Analyze(opts)
 	require.NoError(t, err)
 
 	require.Equal(t, expected.String(), actual.String())


### PR DESCRIPTION
# What?

While one of the internal reviews of another pull request that relies on that library, there was a valid concern raised that if we provide a go library it makes more sense to rely on the standard interfaces and use less file system, which is even currently seems to be possible, but it requires full copy of archive.

This minor change makes it possible to use directly `io.Reader` in the `k6deps.Source`

# Why?

Make API more go idiomatic and potentially reduce some steps