### PR TITLE
process archive in mememory

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -2,58 +2,13 @@ package k6deps
 
 import (
 	"archive/tar"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
-	"os"
 	"path/filepath"
-	"strings"
-
-	"github.com/grafana/k6pack"
+	"slices"
 )
-
-//nolint:forbidigo
-func loadMetadata(dir string, opts *Options) error {
-	var meta archiveMetadata
-
-	data, err := os.ReadFile(filepath.Join(filepath.Clean(dir), "metadata.json"))
-	if err != nil {
-		return err
-	}
-
-	if err = json.Unmarshal(data, &meta); err != nil {
-		return err
-	}
-
-	opts.Manifest.Ignore = true // no manifest (yet) in archive
-
-	opts.Script.Name = filepath.Join(
-		dir,
-		"file",
-		filepath.FromSlash(strings.TrimPrefix(meta.Filename, "file:///")),
-	)
-
-	if value, found := meta.Env[EnvDependencies]; found {
-		opts.Env.Name = EnvDependencies
-		opts.Env.Contents = []byte(value)
-	} else {
-		opts.Env.Ignore = true
-	}
-
-	contents, err := os.ReadFile(opts.Script.Name)
-	if err != nil {
-		return err
-	}
-
-	script, _, err := k6pack.Pack(string(contents), &k6pack.Options{Filename: opts.Script.Name})
-	if err != nil {
-		return err
-	}
-
-	opts.Script.Contents = script
-
-	return nil
-}
 
 type archiveMetadata struct {
 	Filename string            `json:"filename"`
@@ -62,97 +17,73 @@ type archiveMetadata struct {
 
 const maxFileSize = 1024 * 1024 * 10 // 10M
 
-//nolint:forbidigo
-func extractArchive(dir string, input io.Reader) error {
+func processArchive(input io.Reader) (analyzer, error) {
 	reader := tar.NewReader(input)
+
+	analyzers := make([]analyzer, 0)
 
 	for {
 		header, err := reader.Next()
 
 		switch {
-		case err == io.EOF:
-			return nil
+		case errors.Is(err, io.EOF):
+			return mergeAnalyzers(analyzers...), nil
 		case err != nil:
-			return err
+			return nil, err
 		case header == nil:
 			continue
 		}
 
-		target := filepath.Join(dir, filepath.Clean(filepath.FromSlash(header.Name)))
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(target, 0o750); err != nil {
-				return err
-			}
-
-		case tar.TypeReg:
-			if shouldSkip(target) {
-				continue
-			}
-
-			file, err := os.OpenFile(filepath.Clean(target), os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec
-			if err != nil {
-				return err
-			}
-
-			if _, err := io.CopyN(file, reader, maxFileSize); err != nil && !errors.Is(err, io.EOF) {
-				return err
-			}
-
-			if err = file.Close(); err != nil {
-				return err
-			}
-
-		// if it is a link or symlink, we copy the content of the linked file to the target
-		// we assume the linked file was already processed and exists in the directory.
-		case tar.TypeLink, tar.TypeSymlink:
-			if shouldSkip(target) {
-				continue
-			}
-
-			linkedFile := filepath.Join(dir, filepath.Clean(filepath.FromSlash(header.Linkname)))
-			if err := followLink(linkedFile, target); err != nil {
-				return err
-			}
+		if header.Typeflag != tar.TypeReg || !shouldProcess(header.Name) {
+			continue
 		}
+
+		content := &bytes.Buffer{}
+		if _, err := io.CopyN(content, reader, maxFileSize); err != nil && !errors.Is(err, io.EOF) {
+			return nil, err
+		}
+
+		// if the file is metadata.json, we extract the dependencies from the env
+		if header.Name == "metadata.json" {
+			analyzer, err := analizeMetadata(content.Bytes())
+			if err != nil {
+				return nil, err
+			}
+			analyzers = append(analyzers, analyzer)
+			continue
+		}
+
+		// analize the file content as an script
+		target := filepath.Clean(filepath.FromSlash(header.Name))
+		src := Source{
+			Name:     target,
+			Contents: content.Bytes(),
+		}
+
+		analyzers = append(analyzers, scriptAnalyzer(src))
 	}
 }
 
-// indicates if the file should be skipped during extraction
-// we skip csv files and .json except metadata.json
-func shouldSkip(target string) bool {
+// indicates if the file should be processed during extraction
+func shouldProcess(target string) bool {
 	ext := filepath.Ext(target)
-	return ext == ".csv" || (ext == ".json" && filepath.Base(target) != "metadata.json")
+	return slices.Contains([]string{".js", ".ts"}, ext) || slices.Contains([]string{"metadata.json", "data"}, target)
 }
 
-//nolint:forbidigo
-func followLink(linkedFile string, target string) error {
-	source, err := os.Open(filepath.Clean(linkedFile))
-	if err != nil {
-		return err
-	}
-	defer source.Close() //nolint:errcheck
-
-	// we need to get the lined file info to create the target file with the same permissions
-	info, err := source.Stat()
-	if err != nil {
-		return err
+// analizeMetadata extracts the dependencies from the metadata.json file
+func analizeMetadata(content []byte) (analyzer, error) {
+	metadata := archiveMetadata{}
+	if err := json.Unmarshal(content, &metadata); err != nil {
+		return nil, err
 	}
 
-	file, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY, info.Mode()) //nolint:gosec
-	if err != nil {
-		return err
+	if value, found := metadata.Env[EnvDependencies]; found {
+		src := Source{
+			Name:     EnvDependencies,
+			Contents: []byte(value),
+		}
+		return envAnalyzer(src), nil
 	}
 
-	_, err = io.Copy(file, source)
-	if err != nil {
-		return err
-	}
-
-	err = file.Close()
-	if err != nil {
-		return err
-	}
-	return nil
+	return empty, nil
 }

--- a/archive_test.go
+++ b/archive_test.go
@@ -43,11 +43,10 @@ func Test_analyzeArchive_Reader(t *testing.T) {
 		Archive: Source{Reader: file},
 	}
 
+	expected := &Dependencies{}
+	_ = expected.UnmarshalText([]byte(`k6>0.54;k6/x/faker>0.4.0;k6/x/sql>=1.0.1;k6/x/sql/driver/ramsql*`))
+
 	actual, err := Analyze(opts)
 	require.NoError(t, err)
-
-	expected, err := Analyze(opts)
-	require.NoError(t, err)
-
 	require.Equal(t, expected.String(), actual.String())
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -92,16 +92,15 @@ func deps(opts *options, args []string) error {
 	}
 
 	if opts.input != "" && !ignoreStdin {
-		buffer := &bytes.Buffer{}
-		buffer.ReadFrom(os.Stdin) //nolint:errcheck,forbidigo,gosec
-
 		switch opts.input {
 		case "js":
+			buffer := &bytes.Buffer{}
+			buffer.ReadFrom(os.Stdin) //nolint:errcheck,forbidigo,gosec
 			opts.Script.Name = "stdin"
 			opts.Script.Contents = buffer.Bytes()
 		case "tar":
 			opts.Archive.Name = "stdin"
-			opts.Archive.Contents = buffer.Bytes()
+			opts.Archive.Reader = os.Stdin //nolint:forbidigo
 		default:
 			return fmt.Errorf("unsupported input format: %s", opts.input)
 		}


### PR DESCRIPTION
Fixes multiple issues when trying to extract the archive and process it with k6pack, including issues with windows paths.
Also ensures that only the content of the archive is processed.

Closes #70 