### PR TITLE
use source readers

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -19,7 +19,7 @@ func Analyze(opts *Options) (Dependencies, error) {
 	// if the manifest is not provided, we try to find it
 	// if not found, it will be empty and ignored by the analyzer
 	if !opts.Manifest.Ignore && opts.Manifest.IsEmpty() {
-		if err := opts.findManifest(); err != nil {
+		if err := opts.setManifest(); err != nil {
 			return nil, err
 		}
 	}

--- a/analyze_internal_test.go
+++ b/analyze_internal_test.go
@@ -67,7 +67,7 @@ func Test_scriptAnalyzer(t *testing.T) {
 	fn := scriptAnalyzer(src)
 	deps, err := fn()
 
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Empty(t, deps)
 
 	src.Contents = []byte(`"use k6 with @grafana/xk6-faker>v0.3.0";`)

--- a/analyze_internal_test.go
+++ b/analyze_internal_test.go
@@ -1,6 +1,7 @@
 package k6deps
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -63,7 +64,7 @@ func Test_manifestAnalyzer(t *testing.T) {
 func Test_scriptAnalyzer(t *testing.T) {
 	t.Parallel()
 
-	src := Source{Name: "script.js"}
+	src := Source{Name: filepath.Join(t.TempDir(), "script.js")}
 	fn := scriptAnalyzer(src)
 	deps, err := fn()
 

--- a/cmd/help.md
+++ b/cmd/help.md
@@ -2,7 +2,9 @@ Analyze the k6 test script and extract the extensions that the script depends on
 
 ### Sources
 
-Dependencies can come from three sources: k6 test script, manifest file, `K6_DEPENDENCIES` environment variable. Instead of these three sources, a k6 archive can also be specified, which can contain all three sources (currently two actually, because the manifest file is not yet included in the k6 archive).
+Dependencies can come from three sources: k6 test script, manifest file, `K6_DEPENDENCIES` environment variable. Instead of these three sources, a k6 archive can also be specified, which can contain all three sources (currently two actually, because the manifest file is not yet included in the k6 archive). An archive is a tar file, which can be created using the k6 archive command.
+
+> *NOTE*: It is assumed that the script and all dependencies are in the archive. No external dependencies are analyzed.
 
 The name of k6 test script or archive can be specified as the positional argument in the command invocation. Alternatively, the content can be provided in the stdin. If stdin is used, the input format ('js' for script of or 'tar' for archive) must be specified using the `--input` parameter.
 

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package k6deps
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"os"
@@ -30,14 +31,45 @@ func (s *Source) IsEmpty() bool {
 	return len(s.Contents) == 0 && s.Reader == nil && len(s.Name) == 0
 }
 
+func nopCloser() error {
+	return nil
+}
+
+// contentReader returns a reader for the source content.
+func (s *Source) contentReader() (io.Reader, func() error, error) {
+	if s.Reader != nil {
+		return s.Reader, nopCloser, nil
+	}
+
+	if len(s.Contents) > 0 {
+		return bytes.NewReader(s.Contents), nopCloser, nil
+	}
+
+	fileName, err := filepath.Abs(s.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	file, err := os.Open(filepath.Clean(fileName)) //nolint:forbidigo
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return file, file.Close, nil
+}
+
 // Options contains the parameters of the dependency analysis.
 type Options struct {
 	// Script contains the properties of the k6 test script to be analyzed.
+	// If the name is specified, but no content is provided, the script is read from the file.
+	// Any script file referenced will be recursively loaded and the dependencies merged.
+	// If the Ignore property is set, the script will not be analyzed.
 	Script Source
 	// Archive contains the properties of the k6 archive to be analyzed.
 	// If archive is specified, the other three sources will not be taken into account,
 	// since the archive may contain them.
-	// An archive is a tar file, which can be created using the k6 archive command, for example.
+	// It is assumed that the script and all dependencies are in the archive. No external dependencies are analyzed.
+	// An archive is a tar file, which can be created using the k6 archive command.
 	Archive Source
 	// Manifest contains the properties of the manifest file to be analyzed.
 	// If the Ignore property is not set and no manifest file is specified,
@@ -51,20 +83,12 @@ type Options struct {
 	// specified in the Env option Name if the Contents of the Env option is empty.
 	// If empty, os.LookupEnv will be used.
 	LookupEnv func(key string) (value string, ok bool)
-	// FindManifest function is used to find manifest file for the given scriptfile
+	// FindManifest function is used to find manifest file for the given script file
 	// if the Contents of Manifest option is empty.
 	// If the scriptfile parameter is empty, FindManifest starts searching
 	// for the manifest file from the current directory
 	// If missing, the closest manifest file will be used.
-	FindManifest func(scriptfile string) (contents []byte, filename string, ok bool, err error)
-}
-
-func (opts *Options) findManifest(filename string) ([]byte, string, bool, error) {
-	if opts.FindManifest != nil {
-		return opts.FindManifest(filename)
-	}
-
-	return findManifest(filename)
+	FindManifest func(scriptfile string) (filename string, ok bool, err error)
 }
 
 func (opts *Options) lookupEnv(key string) (string, bool) {
@@ -73,49 +97,6 @@ func (opts *Options) lookupEnv(key string) (string, bool) {
 	}
 
 	return os.LookupEnv(key) //nolint:forbidigo
-}
-
-func loadSources(opts *Options) error {
-	if err := loadManifest(opts); err != nil {
-		return err
-	}
-
-	if err := loadScript(opts); err != nil {
-		return err
-	}
-
-	loadEnv(opts)
-
-	return nil
-}
-
-func loadManifest(opts *Options) error {
-	if len(opts.Manifest.Name) == 0 && !opts.Manifest.Ignore {
-		pkg, pkgfile, found, err := opts.findManifest(opts.Script.Name)
-		if err != nil {
-			return err
-		}
-
-		if found {
-			opts.Manifest.Name = pkgfile
-			opts.Manifest.Contents = pkg
-		}
-
-		return nil
-	}
-
-	if len(opts.Manifest.Name) == 0 || len(opts.Manifest.Contents) > 0 || opts.Manifest.Ignore {
-		return nil
-	}
-
-	pkg, err := os.ReadFile(opts.Manifest.Name) //nolint:forbidigo
-	if err != nil {
-		return err
-	}
-
-	opts.Manifest.Contents = pkg
-
-	return nil
 }
 
 func loadScript(opts *Options) error {
@@ -163,21 +144,32 @@ func loadEnv(opts *Options) {
 	opts.Env.Contents = []byte(value)
 }
 
-func findManifest(filename string) ([]byte, string, bool, error) {
+func (opts *Options) findManifest() error {
+	path, found, err := findManifest(opts.Script.Name)
+	if err != nil {
+		return err
+	}
+	if found {
+		opts.Manifest.Name = path
+	}
+
+	return nil
+}
+
+func findManifest(filename string) (string, bool, error) {
 	if len(filename) == 0 {
 		filename = "any_file"
 	}
 
 	abs, err := filepath.Abs(filename)
 	if err != nil {
-		return nil, "", false, err
+		return "", false, err
 	}
 
 	for dir := filepath.Dir(abs); ; dir = filepath.Dir(dir) {
 		filename := filepath.Clean(filepath.Join(dir, "package.json"))
 		if _, err := os.Stat(filename); !errors.Is(err, os.ErrNotExist) { //nolint:forbidigo
-			contents, err := os.ReadFile(filename) //nolint:forbidigo
-			return contents, filename, err == nil, err
+			return filename, err == nil, err
 		}
 
 		if dir[len(dir)-1] == filepath.Separator {
@@ -185,5 +177,5 @@ func findManifest(filename string) ([]byte, string, bool, error) {
 		}
 	}
 
-	return nil, "", false, nil
+	return "", false, nil
 }

--- a/options.go
+++ b/options.go
@@ -144,7 +144,9 @@ func loadEnv(opts *Options) {
 	opts.Env.Contents = []byte(value)
 }
 
-func (opts *Options) findManifest() error {
+func (opts *Options) setManifest() error {
+	// if the manifest is not provided, we try to find it
+	// starting from the location of the script
 	path, found, err := findManifest(opts.Script.Name)
 	if err != nil {
 		return err


### PR DESCRIPTION
Use the source's reader when analyzing dependencies.

The source's reader comes from the content or from reading the source's file (this applies to archive, script, and manifest). For the Environment source, it is assumed that the content is always present.

Breaking changes:
* If the script source is given a name but not content, the name is used as the script's file and its content is tried to be read. Before this was not the case because it was assumed the content was already read always.
* The signature of the FindManifest function changed and it now does not return the content, only the path. 